### PR TITLE
fix: Post Entity에 매핑 추가

### DIFF
--- a/src/main/java/com/example/we_save/domain/post/entity/Post.java
+++ b/src/main/java/com/example/we_save/domain/post/entity/Post.java
@@ -1,9 +1,11 @@
 package com.example.we_save.domain.post.entity;
 
+import com.example.we_save.apiPayload.code.BaseEntity;
+import com.example.we_save.domain.region.entity.EupmyeondongRegion;
+import com.example.we_save.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -12,17 +14,19 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Post  {
+public class Post extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    @Column(nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private EupmyeondongRegion region;
 
-    @Column(nullable = false)
-    private Long categoryId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
 
     @Column(nullable = false, length = 100)
     private String title;
@@ -56,10 +60,6 @@ public class Post  {
 
     @Column(nullable = false)
     private boolean report119;
-
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
 
     private int reportCount;
 }

--- a/src/main/java/com/example/we_save/domain/post/entity/PostImage.java
+++ b/src/main/java/com/example/we_save/domain/post/entity/PostImage.java
@@ -1,0 +1,21 @@
+package com.example.we_save.domain.post.entity;
+
+import com.example.we_save.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class PostImage extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(nullable = false)
+    private String imageUrl;
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 수정
- [x] 기능 추가

### 반영 브랜치
27-feat-post-entity-수정

### 변경 사항
- Post.java (게시물 Entity) 파일에 JoinColumn을 추가했습니다.
- 기존에 String으로 저장되었던 다른 테이블의 외래키를 다른 테이블의 타입으로 저장합니다.
- PostImage Entity를 추가했습니다.
 
   ```JAVA
    // 예시
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "region_id")
    private EupmyeondongRegion region;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "category_id")
    private Category category;
  ````
- region 테이블의 경우 타입을 String에서 EupmyeondongRgion으로 변경했습니다.

### 테스트 결과
Post Entity 변경으로 다른 로직에서 컴파일 에러가 뜨기에 테스트를 진행하진 못했습니다.

### 향후 일정
- Post Entity와 마찬가지로 Comment Entity도 이와 같은 방식으로 수정이 되어야 합니다.