### PR TITLE
국내 게시글 목록 구현 완료

### DIFF
--- a/src/main/java/com/example/we_save/domain/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/we_save/domain/comment/application/CommentServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.we_save.domain.comment.application;
 import com.example.we_save.apiPayload.ApiResponse;
 import com.example.we_save.apiPayload.code.status.ErrorStatus;
 import com.example.we_save.apiPayload.code.status.SuccessStatus;
+import com.example.we_save.apiPayload.util.RegionUtil;
 import com.example.we_save.domain.comment.controller.request.CommentRequestDto;
 import com.example.we_save.domain.comment.controller.response.CommentResponseDto;
 import com.example.we_save.domain.comment.entity.Comment;
@@ -21,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -41,6 +41,9 @@ public class CommentServiceImpl implements CommentService {
 
     @Autowired
     private CommentImageRepository commentImageRepository;
+
+    @Autowired
+    private RegionUtil regionUtil;
 
     private static final int MAX_IMAGE_COUNT = 10;
     private static final int MAX_REPORT_COUNT = 10;
@@ -171,13 +174,8 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public ApiResponse<Void> reportComment(Long commentId, Long userId) {
 
-        Optional<Comment> optionalComment = commentRepository.findById(commentId);
-
-        if (!optionalComment.isPresent()) {
-            return ApiResponse.onFailure(ErrorStatus._BAD_REQUEST.getCode(), "잘못된 요청입니다.", null);
-        }
-
-        Comment comment = optionalComment.get();
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다."));
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));

--- a/src/main/java/com/example/we_save/domain/post/applicaiton/PostService.java
+++ b/src/main/java/com/example/we_save/domain/post/applicaiton/PostService.java
@@ -3,9 +3,12 @@ package com.example.we_save.domain.post.applicaiton;
 import com.example.we_save.apiPayload.ApiResponse;
 import com.example.we_save.domain.post.controller.request.NearbyPostRequestDto;
 import com.example.we_save.domain.post.controller.request.PostRequestDto;
+import com.example.we_save.domain.post.controller.response.DomesticPostDto;
 import com.example.we_save.domain.post.controller.response.NearbyPostResponseDto;
 import com.example.we_save.domain.post.controller.response.PostResponseDto;
 import com.example.we_save.domain.post.controller.response.PostResponseDtoWithComments;
+
+import java.util.List;
 
 public interface PostService {
     ApiResponse<PostResponseDto> createPost(PostRequestDto postRequestDto);
@@ -18,4 +21,6 @@ public interface PostService {
     ApiResponse<NearbyPostResponseDto> getRecentNearbyPosts(NearbyPostRequestDto nearbyPostRequestDto, int page, boolean excludeCompleted);
     ApiResponse<NearbyPostResponseDto> getTopNearbyPosts(NearbyPostRequestDto nearbyPostRequestDto, int page, boolean excludeCompleted);
     ApiResponse<NearbyPostResponseDto> getDistanceNearbyPosts(NearbyPostRequestDto nearbyPostRequestDto, int page, boolean excludeCompleted);
+    ApiResponse<List<DomesticPostDto>> getRecentDomesticPosts(boolean excludeCompleted);
+    ApiResponse<List<DomesticPostDto>> getTopDomesticPosts(boolean excludeCompleted);
 }

--- a/src/main/java/com/example/we_save/domain/post/applicaiton/PostServiceImpl.java
+++ b/src/main/java/com/example/we_save/domain/post/applicaiton/PostServiceImpl.java
@@ -10,10 +10,7 @@ import com.example.we_save.domain.comment.entity.CommentImage;
 import com.example.we_save.domain.comment.repository.CommentRepository;
 import com.example.we_save.domain.post.controller.request.NearbyPostRequestDto;
 import com.example.we_save.domain.post.controller.request.PostRequestDto;
-import com.example.we_save.domain.post.controller.response.NearbyPostResponseDto;
-import com.example.we_save.domain.post.controller.response.PostDto;
-import com.example.we_save.domain.post.controller.response.PostResponseDto;
-import com.example.we_save.domain.post.controller.response.PostResponseDtoWithComments;
+import com.example.we_save.domain.post.controller.response.*;
 import com.example.we_save.domain.post.entity.*;
 import com.example.we_save.domain.post.repository.*;
 import com.example.we_save.domain.region.entity.EupmyeondongRegion;
@@ -420,5 +417,41 @@ public class PostServiceImpl implements PostService {
         double postLatitude = post.getLatitude();
         double postLongitude = post.getLongitude();
         return RegionUtil.calculateDistanceBetweenCoordinates(postLatitude, postLongitude, latitude, longitude);
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse<List<DomesticPostDto>> getRecentDomesticPosts(boolean excludeCompleted) {
+        List<Post> posts;
+
+        if (excludeCompleted) {
+            posts = postRepository.findRecentDomesticPostsExcludingCompleted(PageRequest.of(0, 10));
+        } else {
+            posts = postRepository.findRecentDomesticPosts(PageRequest.of(0, 10));
+        }
+
+        List<DomesticPostDto> postDTOs = posts.stream()
+                .map(DomesticPostDto::of)
+                .collect(Collectors.toList());
+
+        return ApiResponse.onGetSuccess(postDTOs);
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse<List<DomesticPostDto>> getTopDomesticPosts(boolean excludeCompleted) {
+        List<Post> posts;
+
+        if (excludeCompleted) {
+            posts = postRepository.findTopDomesticPostsExcludingCompleted(PageRequest.of(0, 10));
+        } else {
+            posts = postRepository.findTopDomesticPosts(PageRequest.of(0, 10));
+        }
+
+        List<DomesticPostDto> postDTOs = posts.stream()
+                .map(DomesticPostDto::of)
+                .collect(Collectors.toList());
+
+        return ApiResponse.onGetSuccess(postDTOs);
     }
 }

--- a/src/main/java/com/example/we_save/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/we_save/domain/post/controller/PostController.java
@@ -4,12 +4,15 @@ import com.example.we_save.apiPayload.ApiResponse;
 import com.example.we_save.domain.post.applicaiton.PostService;
 import com.example.we_save.domain.post.controller.request.NearbyPostRequestDto;
 import com.example.we_save.domain.post.controller.request.PostRequestDto;
+import com.example.we_save.domain.post.controller.response.DomesticPostDto;
 import com.example.we_save.domain.post.controller.response.NearbyPostResponseDto;
 import com.example.we_save.domain.post.controller.response.PostResponseDto;
 import com.example.we_save.domain.post.controller.response.PostResponseDtoWithComments;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -93,5 +96,19 @@ public class PostController {
             @RequestParam("page") int page,
             @RequestParam("excludeCompleted") boolean excludeCompleted) {
         return ResponseEntity.ok(postService.getDistanceNearbyPosts(nearbyPostRequestDto, page, excludeCompleted));
+    }
+
+    @GetMapping("/posts/domestic/recent")
+    public ResponseEntity<ApiResponse<List<DomesticPostDto>>> getRecentDomesticPosts(
+            @RequestParam(value = "excludeCompleted", required = false, defaultValue = "false") boolean excludeCompleted) {
+        ApiResponse<List<DomesticPostDto>> response = postService.getRecentDomesticPosts(excludeCompleted);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/posts/domestic/top")
+    public ResponseEntity<ApiResponse<List<DomesticPostDto>>> getTopDomesticPosts(
+            @RequestParam(value = "excludeCompleted", required = false, defaultValue = "false") boolean excludeCompleted) {
+        ApiResponse<List<DomesticPostDto>> response = postService.getTopDomesticPosts(excludeCompleted);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/we_save/domain/post/controller/response/DomesticPostDto.java
+++ b/src/main/java/com/example/we_save/domain/post/controller/response/DomesticPostDto.java
@@ -1,0 +1,43 @@
+package com.example.we_save.domain.post.controller.response;
+
+import com.example.we_save.apiPayload.util.RegionUtil;
+import com.example.we_save.domain.post.entity.Category;
+import com.example.we_save.domain.post.entity.Post;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DomesticPostDto {
+    private Long postId;
+    private Category category;
+    private String title;
+    private String content;
+    private String postRegionName;
+    private int hearts;
+    private int dislikes;
+    private String image;
+    private int imageCount;
+    private String createdAt;
+
+    public static DomesticPostDto of(Post post) {
+        return DomesticPostDto.builder()
+                .postId(post.getId())
+                .category(post.getCategory())
+                .title(post.getTitle())
+                .content(post.getContent().substring(0, Math.min(20, post.getContent().length())) + "...")
+                .postRegionName(RegionUtil.extractRegionAfterSecondSpace(post.getPostRegionName()))
+                .hearts(post.getHearts())
+                .dislikes(post.getDislikes())
+                .image(post.getImages().isEmpty() ? null : post.getImages().get(0).getImageUrl())
+                .imageCount(post.getImages().size())
+                .createdAt(post.getCreateAt().toString())
+                .build();
+    }
+
+    public String getCategory() {
+        return category.getValue();
+    }
+}

--- a/src/main/java/com/example/we_save/domain/post/repository/PostDislikeRepository.java
+++ b/src/main/java/com/example/we_save/domain/post/repository/PostDislikeRepository.java
@@ -1,9 +1,7 @@
 package com.example.we_save.domain.post.repository;
 
-import com.example.we_save.domain.post.entity.Post;
+
 import com.example.we_save.domain.post.entity.PostDislike;
-import com.example.we_save.domain.post.entity.PostHeart;
-import com.example.we_save.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostDislikeRepository extends JpaRepository<PostDislike, Long> {

--- a/src/main/java/com/example/we_save/domain/post/repository/PostHeartRepository.java
+++ b/src/main/java/com/example/we_save/domain/post/repository/PostHeartRepository.java
@@ -1,9 +1,8 @@
 package com.example.we_save.domain.post.repository;
 
-import com.example.we_save.domain.post.entity.Post;
 import com.example.we_save.domain.post.entity.PostHeart;
-import com.example.we_save.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 public interface PostHeartRepository extends JpaRepository<PostHeart, Long> {
     boolean existsByPostIdAndUserId(Long postId, Long userId);
     void deleteByPostIdAndUserId(Long postId, Long userId);

--- a/src/main/java/com/example/we_save/domain/post/repository/PostReportRepository.java
+++ b/src/main/java/com/example/we_save/domain/post/repository/PostReportRepository.java
@@ -1,8 +1,6 @@
 package com.example.we_save.domain.post.repository;
 
-import com.example.we_save.domain.post.entity.Post;
 import com.example.we_save.domain.post.entity.PostReport;
-import com.example.we_save.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {

--- a/src/main/java/com/example/we_save/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/we_save/domain/post/repository/PostRepository.java
@@ -11,6 +11,22 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    // 국내 게시글 최신순 조회 (상황 종료 제외)
+    @Query("SELECT p FROM Post p WHERE p.hearts >= 10 AND p.status != 'COMPLETED' ORDER BY p.createAt DESC")
+    List<Post> findRecentDomesticPostsExcludingCompleted(Pageable pageable);
+
+    // 국내 게시글 최신순 조회 (상황 종료 포함)
+    @Query("SELECT p FROM Post p WHERE p.hearts >= 10 ORDER BY p.createAt DESC")
+    List<Post> findRecentDomesticPosts(Pageable pageable);
+
+    // 국내 게시글 확인순 조회 (상황 종료 제외)
+    @Query("SELECT p FROM Post p WHERE p.hearts >= 10 AND p.status != 'COMPLETED' ORDER BY p.hearts DESC")
+    List<Post> findTopDomesticPostsExcludingCompleted(Pageable pageable);
+
+    // 국내 게시글 확인순 조회 (상황 종료 포함)
+    @Query("SELECT p FROM Post p WHERE p.hearts >= 10 ORDER BY p.hearts DESC")
+    List<Post> findTopDomesticPosts(Pageable pageable);
+
     @Query("SELECT p FROM Post p WHERE p.createAt >= :startDate AND p.region.id = :regionId AND p.status != 'COMPLETED' ORDER BY p.createAt DESC")
     List<Post> findRecentPostsExcludingCompleted(@Param("startDate") LocalDateTime startDate,
                                                  @Param("regionId") Long regionId,


### PR DESCRIPTION
국내 게시글 목록 구현 완료했습니다.

-  게시글 갯수 10개로 제한한다
- 확인순, 최신순으로 나눠 각각 상황종료 제외, 포함하여 보여준다