### PR TITLE
[Feat] 해시태그를 기반으로 한 검색 기능

### DIFF
--- a/src/main/java/com/example/we_save/domain/countermeasure/controller/response/HomeSearchResponseDto.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/controller/response/HomeSearchResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.we_save.domain.countermeasure.controller.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+@Data
+public class HomeSearchResponseDto {
+
+    private List<String> tags;
+    private List<CountermeasureResponseDto> countermeasureDtos;
+}

--- a/src/main/java/com/example/we_save/domain/countermeasure/entity/CountermeasureHashTag.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/entity/CountermeasureHashTag.java
@@ -1,14 +1,21 @@
 package com.example.we_save.domain.countermeasure.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class CountermeasureHashTag {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private long id = 0L;
 
-    @Column(nullable = false, length = 10)
-    private String tagName;
+    @ManyToOne
+    @JoinColumn(name = "countermeasure_id", nullable = false)
+    private Countermeasure countermeasure;
+
+    @ManyToOne
+    @JoinColumn(name = "hashtag_id", nullable = false)
+    private HashTag hashTag;
 }

--- a/src/main/java/com/example/we_save/domain/countermeasure/entity/CountermeasureHashTag.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/entity/CountermeasureHashTag.java
@@ -1,0 +1,14 @@
+package com.example.we_save.domain.countermeasure.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class CountermeasureHashTag {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private long id = 0L;
+
+    @Column(nullable = false, length = 10)
+    private String tagName;
+}

--- a/src/main/java/com/example/we_save/domain/countermeasure/entity/HashTag.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/entity/HashTag.java
@@ -1,0 +1,19 @@
+package com.example.we_save.domain.countermeasure.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class HashTag {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private long id = 0L;
+
+    @ManyToOne
+    @JoinColumn(name = "countermeasure_id", nullable = false)
+    private Countermeasure countermeasure;
+
+    @ManyToOne
+    @JoinColumn(name = "hashtag_id", nullable = false)
+    private HashTag hashTag;
+}

--- a/src/main/java/com/example/we_save/domain/countermeasure/entity/HashTag.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/entity/HashTag.java
@@ -1,19 +1,16 @@
 package com.example.we_save.domain.countermeasure.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class HashTag {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private long id = 0L;
 
-    @ManyToOne
-    @JoinColumn(name = "countermeasure_id", nullable = false)
-    private Countermeasure countermeasure;
-
-    @ManyToOne
-    @JoinColumn(name = "hashtag_id", nullable = false)
-    private HashTag hashTag;
+    @Column(nullable = false, length = 10)
+    private String tagName;
 }

--- a/src/main/java/com/example/we_save/domain/countermeasure/repository/CountermeasureHashTagRepository.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/repository/CountermeasureHashTagRepository.java
@@ -1,0 +1,7 @@
+package com.example.we_save.domain.countermeasure.repository;
+
+import com.example.we_save.domain.countermeasure.entity.CountermeasureHashTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CountermeasureHashTagRepository extends JpaRepository<CountermeasureHashTag, Long> {
+}

--- a/src/main/java/com/example/we_save/domain/countermeasure/repository/CountermeasureHashTagRepository.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/repository/CountermeasureHashTagRepository.java
@@ -3,5 +3,9 @@ package com.example.we_save.domain.countermeasure.repository;
 import com.example.we_save.domain.countermeasure.entity.CountermeasureHashTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CountermeasureHashTagRepository extends JpaRepository<CountermeasureHashTag, Long> {
+
+    List<CountermeasureHashTag> findAllByHashTag_TagName(String hashTag);
 }

--- a/src/main/java/com/example/we_save/domain/countermeasure/repository/HashTagRepository.java
+++ b/src/main/java/com/example/we_save/domain/countermeasure/repository/HashTagRepository.java
@@ -1,0 +1,7 @@
+package com.example.we_save.domain.countermeasure.repository;
+
+import com.example.we_save.domain.countermeasure.entity.HashTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+}

--- a/src/main/java/com/example/we_save/domain/home/application/HomeService.java
+++ b/src/main/java/com/example/we_save/domain/home/application/HomeService.java
@@ -1,7 +1,7 @@
 package com.example.we_save.domain.home.application;
 
 import com.example.we_save.apiPayload.ApiResponse;
-import com.example.we_save.domain.countermeasure.controller.response.CountermeasureResponseDto;
+import com.example.we_save.domain.countermeasure.controller.response.HomeSearchResponseDto;
 import com.example.we_save.domain.home.controller.request.HomeLocationRequestDto;
 import com.example.we_save.domain.home.controller.response.HomeResponseDto;
 import com.example.we_save.domain.post.controller.response.NearPostHomeResponseDto;
@@ -14,5 +14,5 @@ public interface HomeService {
     ApiResponse<List<NearPostHomeResponseDto>> showRecentNearPosts(HomeLocationRequestDto locationDto);
     ApiResponse<List<NearPostHomeResponseDto>> showTopNearPosts(HomeLocationRequestDto locationDto);
     ApiResponse<List<NearPostHomeResponseDto>> showDistanceNearPosts(HomeLocationRequestDto locationDto);
-    ApiResponse<List<CountermeasureResponseDto>> findCountermeasuresByKeyword(String keyword);
+    ApiResponse<HomeSearchResponseDto> findCountermeasuresByTag(String tag);
 }

--- a/src/main/java/com/example/we_save/domain/home/application/HomeServiceImpl.java
+++ b/src/main/java/com/example/we_save/domain/home/application/HomeServiceImpl.java
@@ -70,7 +70,8 @@ public class HomeServiceImpl implements HomeService {
     @Override
     public ApiResponse<HomeSearchResponseDto> findCountermeasuresByTag(String tag) {
 
-        List<String> tags = Arrays.asList(tag.split("\\s+"));
+        String cleanedTag = tag.replaceAll("[\\p{Punct}]+", "");
+        List<String> tags = Arrays.asList(cleanedTag.split("\\s+"));
         Set<Countermeasure> countermeasureSet = new HashSet<>();
         Set<String> foundTags = new HashSet<>();
 

--- a/src/main/java/com/example/we_save/domain/home/application/HomeServiceImpl.java
+++ b/src/main/java/com/example/we_save/domain/home/application/HomeServiceImpl.java
@@ -3,8 +3,10 @@ package com.example.we_save.domain.home.application;
 import com.example.we_save.apiPayload.ApiResponse;
 import com.example.we_save.apiPayload.util.RegionUtil;
 import com.example.we_save.domain.countermeasure.controller.response.CountermeasureResponseDto;
+import com.example.we_save.domain.countermeasure.controller.response.HomeSearchResponseDto;
 import com.example.we_save.domain.countermeasure.entity.Countermeasure;
-import com.example.we_save.domain.countermeasure.repository.CountermeasureRepository;
+import com.example.we_save.domain.countermeasure.entity.CountermeasureHashTag;
+import com.example.we_save.domain.countermeasure.repository.CountermeasureHashTagRepository;
 import com.example.we_save.domain.home.controller.request.HomeLocationRequestDto;
 import com.example.we_save.domain.home.controller.response.HomeResponseDto;
 import com.example.we_save.domain.post.controller.response.HotPostHomeResponseDto;
@@ -17,7 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,7 +28,7 @@ public class HomeServiceImpl implements HomeService {
 
     private final PostRepository postRepository;
     private final RegionUtil regionUtil;
-    private final CountermeasureRepository countermeasureRepository;
+    private final CountermeasureHashTagRepository countermeasureHashTagRepository;
 
     private final int LIMIT = 10;
     private final int RECENT = 0;
@@ -66,15 +68,33 @@ public class HomeServiceImpl implements HomeService {
     }
 
     @Override
-    public ApiResponse<List<CountermeasureResponseDto>> findCountermeasuresByKeyword(String keyword) {
+    public ApiResponse<HomeSearchResponseDto> findCountermeasuresByTag(String tag) {
 
-        List<Countermeasure> countermeasures = countermeasureRepository.findAllByTitleContainingOrMainContentContaining(keyword);
+        List<String> tags = Arrays.asList(tag.split("\\s+"));
+        Set<Countermeasure> countermeasureSet = new HashSet<>();
+        Set<String> foundTags = new HashSet<>();
 
+        tags.forEach((hashtag) -> {
+            List<CountermeasureHashTag> countermeasureHashTags
+                    = countermeasureHashTagRepository.findAllByHashTag_TagName(hashtag);
+            countermeasureHashTags.forEach(countermeasureHashTag -> {
+                countermeasureSet.add(countermeasureHashTag.getCountermeasure());
+                foundTags.add(countermeasureHashTag.getHashTag().getTagName());
+            });
+        });
+
+        List<Countermeasure> countermeasures = new ArrayList<>(countermeasureSet);
+        List<String> foundTagList = new ArrayList<>(foundTags);
         List<CountermeasureResponseDto> countermeasureDtos = countermeasures.stream()
                 .map(CountermeasureResponseDto::of)
                 .collect(Collectors.toList());
 
-        return ApiResponse.onGetSuccess(countermeasureDtos);
+        HomeSearchResponseDto homeSearchResponseDto = HomeSearchResponseDto.builder()
+                .tags(foundTagList)
+                .countermeasureDtos(countermeasureDtos)
+                .build();
+
+        return ApiResponse.onGetSuccess(homeSearchResponseDto);
     }
 
     private List<NearPostHomeResponseDto> getNearDisasterPages(HomeLocationRequestDto locationDto, int limit, int type) {

--- a/src/main/java/com/example/we_save/domain/home/controller/HomeController.java
+++ b/src/main/java/com/example/we_save/domain/home/controller/HomeController.java
@@ -1,7 +1,7 @@
 package com.example.we_save.domain.home.controller;
 
 import com.example.we_save.apiPayload.ApiResponse;
-import com.example.we_save.domain.countermeasure.controller.response.CountermeasureResponseDto;
+import com.example.we_save.domain.countermeasure.controller.response.HomeSearchResponseDto;
 import com.example.we_save.domain.home.application.HomeService;
 import com.example.we_save.domain.home.controller.request.HomeLocationRequestDto;
 import com.example.we_save.domain.home.controller.response.HomeResponseDto;
@@ -50,14 +50,14 @@ public class HomeController {
 
     @Operation(summary = "메인페이지 검색")
     @GetMapping("/search")
-    ResponseEntity<ApiResponse<List<CountermeasureResponseDto>>> searchCountermeasures
-            (@RequestParam(value = "keyword", required = false) String keyword) {
+    ResponseEntity<ApiResponse<HomeSearchResponseDto>> searchCountermeasures
+            (@RequestParam(value = "tag", required = false) String tag) {
 
         // 검색어가 없을 경우 실패 응답 반환
-        if (keyword == null || keyword.isEmpty()) {
+        if (tag == null || tag.isEmpty()) {
             return ResponseEntity.ok(ApiResponse.onFailure("400", "Keyword is missing", null));
         }
 
-        return ResponseEntity.ok(homeService.findCountermeasuresByKeyword(keyword));
+        return ResponseEntity.ok(homeService.findCountermeasuresByTag(tag));
     }
 }


### PR DESCRIPTION
## 변경된 내용
### 1. DB 변경
![image](https://github.com/user-attachments/assets/6782381a-3083-453e-85f4-90c8aa955e71)
- 응급처치대처방안은 내부적으로 해시 태그를 저장합니다.
- 해시 태그를 기반으로 검색이 진행됩니다.

### 2. API 명세서 변경
![image](https://github.com/user-attachments/assets/beade44d-bbe4-48d4-a32e-ed8a0d967b61)
- 기존과 달리 tags라는 배열 형태의 응답이 추가되었습니다.
- tags는 해시 태그의 이름을 리턴합니다.

![image](https://github.com/user-attachments/assets/55529cea-d7ef-4fd6-8898-2581de63f59d)
- 관련 키워드는 tags의 모든 요소를 사용합니다.
- '발목 염좌' 응급 처치에서 '발목 염좌'와 같은 문자열은 tags의 첫 번째 요소를 사용합니다.

## 테스트
postman과 localDB에서 테스트 완료했습니다.

## 향후 일정 
검색의 관련성과 속도와 같은 성능을 테스트 해볼 예정입니다.