### PR TITLE
[FEAT] 회원탈퇴 API구현

### DIFF
--- a/src/main/java/com/example/we_save/domain/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/we_save/domain/user/controller/UserAuthController.java
@@ -7,6 +7,7 @@ import com.example.we_save.domain.user.controller.response.UserAuthResponseDto;
 import com.example.we_save.domain.user.converter.UserConverter;
 import com.example.we_save.domain.user.entity.NotificationSetting;
 import com.example.we_save.domain.user.entity.User;
+import com.example.we_save.domain.user.entity.UserStatus;
 import com.example.we_save.domain.user.service.NotificationSettingCommandService;
 import com.example.we_save.domain.user.service.UserAuthCommandService;
 import com.example.we_save.image.entity.Image;
@@ -17,10 +18,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -36,11 +35,11 @@ public class UserAuthController {
 
     @Operation(summary = "회원가입")
     @PostMapping("/users")
-    public ResponseEntity<ApiResponse<UserAuthResponseDto.JoinResultDto>> join(@RequestBody @Valid UserAuthRequestDto.JoinDto request){
+    public ResponseEntity<ApiResponse<UserAuthResponseDto.JoinResultDto>> join(@RequestBody @Valid UserAuthRequestDto.JoinDto request) {
         NotificationSetting notificationSetting = notificationSettingCommandService.createNotificationSetting();
         try {
             Image newProfileImage = imageService.saveDefaultProfileImage(); //파일서버에 프로필 이미지 등록
-            User user = userAuthCommandService.joinUser(request, notificationSetting,newProfileImage);
+            User user = userAuthCommandService.joinUser(request, notificationSetting, newProfileImage);
 
             if (user == null) {
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.onFailure("COMMON409", "이미 회원가입이 된 회원입니다.", null));
@@ -49,39 +48,46 @@ public class UserAuthController {
                 ApiResponse<UserAuthResponseDto.JoinResultDto> response = ApiResponse.onPostSuccess(UserConverter.toJoinResultDto(user), SuccessStatus._POST_OK);
                 return ResponseEntity.status(HttpStatus.CREATED).body(response);
             }
-        }catch (IllegalArgumentException e){
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure("COMMON400",e.getMessage(),null));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure("COMMON400", e.getMessage(), null));
         }
     }
 
     @Operation(summary = "로그인")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse> login(@RequestBody @Valid UserAuthRequestDto.loginDto request){
+    public ResponseEntity<ApiResponse> login(@RequestBody @Valid UserAuthRequestDto.loginDto request) {
         User user = userAuthCommandService.loginUser(request);
 
-        if (user == null){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.onFailure("COMMON401","인증 정보가 잘못되었습니다.",user));
-        }
-        else{
-            String token = jwtUtil.createJwt(user.getId().toString(),"USER",24 * 60 * 60 * 1000L);
-            ApiResponse<UserAuthResponseDto.loginResultDto> response = ApiResponse.onPostSuccess(UserConverter.toLoginResultDto(user,token),SuccessStatus._POST_OK);
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.onFailure("COMMON401", "인증 정보가 잘못되었습니다.", null));
+        } else {
+            if (user.getStatus().equals(UserStatus.SUSPENDED)) { //유저의 상태가 정지일 경우
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.onFailure("COMMON403", "정지된 회원입니다.", UserConverter.toUserStatusResultDto(user)));
+            }
+            if (user.getStatus().equals(UserStatus.INACTIVE)) { //유저의 상태가 비활성화일 경우
+                userAuthCommandService.activateUser(user); //비활성화 해제 -> 로그인 가능
+            }
+
+            String token = jwtUtil.createJwt(user.getId().toString(), "USER", 24 * 60 * 60 * 1000L);
+            ApiResponse<UserAuthResponseDto.loginResultDto> response = ApiResponse.onPostSuccess(UserConverter.toLoginResultDto(user, token), SuccessStatus._POST_OK);
             return ResponseEntity.ok(response);
+
         }
     }
 
 
-    @Operation(summary = "로그인 된 회원 정보(마이페이지-프로필 조회)", security = @SecurityRequirement(name="Authorization"))
+    @Operation(summary = "로그인 된 회원 정보(마이페이지-프로필 조회)", security = @SecurityRequirement(name = "Authorization"))
     @GetMapping("/users")
-    public ResponseEntity<ApiResponse> getUserInfo(){
+    public ResponseEntity<ApiResponse> getUserInfo() {
         User user = userAuthCommandService.getAuthenticatedUserInfo();
         ApiResponse<UserAuthResponseDto.findUserResultDto> response = ApiResponse.onGetSuccess(UserConverter.toUserResultDto(user));
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "로그인 된 회원 정보 수정(마이페이지-프로필 수정)", security = @SecurityRequirement(name="Authorization"))
+    @Operation(summary = "로그인 된 회원 정보 수정(마이페이지-프로필 수정)", security = @SecurityRequirement(name = "Authorization"))
     @PutMapping(value = "/users")
     public ResponseEntity<ApiResponse> updateUserInfo(@RequestPart("nickname") String nickname,
-                                                      @RequestPart(value = "profileImage",required = false) MultipartFile profileImage ){
+                                                      @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
         User user = userAuthCommandService.getAuthenticatedUserInfo();
         try {
 
@@ -96,42 +102,55 @@ public class UserAuthController {
             User updateUser = userAuthCommandService.updateUser(user, nickname, newProfileImage); //유저 정보 업데이트
             ApiResponse<UserAuthResponseDto.findUserResultDto> response = ApiResponse.onGetSuccess(UserConverter.toUserResultDto(updateUser));
             return ResponseEntity.ok(response);
-            
-        }catch (Exception e){
+
+        } catch (Exception e) {
             Image newProfileImage = imageService.saveDefaultProfileImage();
             User updateUser = userAuthCommandService.updateUser(user, nickname, newProfileImage); //유저 정보 업데이트
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure("COMMON400","파일 업로드 오류",UserConverter.toUserResultDto(updateUser)));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure("COMMON400", "파일 업로드 오류", UserConverter.toUserResultDto(updateUser)));
         }
+    }
+
+    @Operation(summary = "회원 탈퇴", security = @SecurityRequirement(name = "Authorization"))
+    @DeleteMapping(value = "/users")
+    public ResponseEntity<ApiResponse> deleteUserInfo() {
+        User user = userAuthCommandService.getAuthenticatedUserInfo();
+        if (user.getStatus().equals(UserStatus.ACTIVE)) {
+            userAuthCommandService.inactiveUser(user);
+            ApiResponse<UserAuthResponseDto.findUserStatusResultDto> response = ApiResponse.onGetSuccess(UserConverter.toUserStatusResultDto(user));
+            return ResponseEntity.ok(response);
+        } else {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.onFailure("COMMON403", "탈퇴 권한이 없는 회원입니다.", UserConverter.toUserStatusResultDto(user)));
+        }
+
     }
 
     @Operation(summary = "유효한 전화번호 확인")
     @GetMapping("/check-phone/{number}")
-    public ResponseEntity<ApiResponse<UserAuthResponseDto.ValidResultDto>>isValidPhoneNum(@PathVariable String number){
+    public ResponseEntity<ApiResponse<UserAuthResponseDto.ValidResultDto>> isValidPhoneNum(@PathVariable String number) {
         Boolean isValid = userAuthCommandService.isValidPhoneNumber(number);
 
         if (isValid) {
             ApiResponse<UserAuthResponseDto.ValidResultDto> response = ApiResponse.onGetSuccess(
                     UserConverter.toValidResultDto(isValid, "유효한 전화번호 입니다."));
             return ResponseEntity.ok(response);
-        }
-        else{
+        } else {
             ApiResponse<UserAuthResponseDto.ValidResultDto> response = ApiResponse.onFailure(
                     "COMMON409", "409 Conflict", UserConverter.toValidResultDto(isValid, "중복된 전화번호 입니다."));
             return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
         }
     }
 
+
     @Operation(summary = "유효한 닉네임 확인")
     @GetMapping("/check-nickname/{nickname}")
-    public ResponseEntity<ApiResponse<UserAuthResponseDto.ValidResultDto>>isValidNickame(@PathVariable String nickname){
+    public ResponseEntity<ApiResponse<UserAuthResponseDto.ValidResultDto>> isValidNickame(@PathVariable String nickname) {
         Boolean isValid = userAuthCommandService.isValidNickname(nickname);
 
         if (isValid) {
             ApiResponse<UserAuthResponseDto.ValidResultDto> response = ApiResponse.onGetSuccess(
                     UserConverter.toValidResultDto(isValid, "유효한 닉네임 입니다."));
             return ResponseEntity.ok(response);
-        }
-        else{
+        } else {
             ApiResponse<UserAuthResponseDto.ValidResultDto> response = ApiResponse.onFailure(
                     "COMMON409", "409 Conflict", UserConverter.toValidResultDto(isValid, "중복된 닉네임 입니다."));
             return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
@@ -140,17 +159,17 @@ public class UserAuthController {
 
     @Operation(summary = "비밀번호 재설정")
     @PatchMapping("/users")
-    public ResponseEntity<ApiResponse> changePassword(@RequestBody @Valid UserAuthRequestDto.changePasswordDto request){
+    public ResponseEntity<ApiResponse> changePassword(@RequestBody @Valid UserAuthRequestDto.changePasswordDto request) {
         // 사용자 정보 조회
         User user = userAuthCommandService.findByUserPhoneNumber(request.getPhoneNum());
-        if (user == null){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.onFailure("COMMON401","해당 전화번호의 회원이 존재하지 않습니다. 회원가입 해주세요. ",null));
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.onFailure("COMMON401", "해당 전화번호의 회원이 존재하지 않습니다. 회원가입 해주세요. ", null));
         }
-        try{
+        try {
             User updateUser = userAuthCommandService.updateUserPassword(user, request.getPassword());
             return ResponseEntity.ok(ApiResponse.onGetSuccess(UserConverter.toUserIdResultDto(updateUser)));
-        }catch (IllegalArgumentException e){
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure("COMMON400",e.getMessage(),null));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure("COMMON400", e.getMessage(), null));
         }
     }
 }

--- a/src/main/java/com/example/we_save/domain/user/controller/response/UserAuthResponseDto.java
+++ b/src/main/java/com/example/we_save/domain/user/controller/response/UserAuthResponseDto.java
@@ -1,7 +1,6 @@
 package com.example.we_save.domain.user.controller.response;
 
 import com.example.we_save.domain.user.entity.UserStatus;
-import com.example.we_save.image.entity.Image;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -13,7 +12,7 @@ public class UserAuthResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class JoinResultDto{
+    public static class JoinResultDto {
         Long userId;
         LocalDateTime createAt;
     }
@@ -22,7 +21,7 @@ public class UserAuthResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ValidResultDto{
+    public static class ValidResultDto {
         Boolean isValid;
         String message;
     }
@@ -31,7 +30,7 @@ public class UserAuthResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class loginResultDto{
+    public static class loginResultDto {
         Long userId;
         String token;
     }
@@ -40,19 +39,29 @@ public class UserAuthResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class findUserResultDto{
+    public static class findUserResultDto {
         Long userId;
         String phoneNum;
         String nickname;
         String imageUrl;
         UserStatus status;
     }
+
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class findUserIdResultDto{
+    public static class findUserIdResultDto {
         Long userId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class findUserStatusResultDto {
+        Long userId;
+        UserStatus status;
     }
 
 

--- a/src/main/java/com/example/we_save/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/we_save/domain/user/converter/UserConverter.java
@@ -48,7 +48,12 @@ public class UserConverter {
                 .userId(user.getId())
                 .build();
     }
-
+    public static UserAuthResponseDto.findUserStatusResultDto toUserStatusResultDto(User user) {
+        return UserAuthResponseDto.findUserStatusResultDto.builder()
+                .userId(user.getId())
+                .status(user.getStatus())
+                .build();
+    }
 
 
 

--- a/src/main/java/com/example/we_save/domain/user/service/UserAuthCommandService.java
+++ b/src/main/java/com/example/we_save/domain/user/service/UserAuthCommandService.java
@@ -5,16 +5,27 @@ import com.example.we_save.domain.user.entity.NotificationSetting;
 import com.example.we_save.domain.user.entity.User;
 import com.example.we_save.image.entity.Image;
 
-import java.util.Optional;
 
 public interface UserAuthCommandService {
-    public User joinUser(UserAuthRequestDto.JoinDto request, NotificationSetting notificationSetting,Image image);
+    public User joinUser(UserAuthRequestDto.JoinDto request, NotificationSetting notificationSetting, Image image);
+
     public User loginUser(UserAuthRequestDto.loginDto request);
+
     public Boolean isValidPhoneNumber(String phoneNumber);
+
     public Boolean isValidNickname(String nickname);
+
     public User findByUserId(long userId);
+
     public User updateUser(User user, String newNickname, Image newProfileImage);
+
+    public void inactiveUser(User user);
+
+    public void activateUser(User user);
+
     public User getAuthenticatedUserInfo();
+
     public User findByUserPhoneNumber(String phoneNumber);
+
     public User updateUserPassword(User user, String newPassword);
 }

--- a/src/main/java/com/example/we_save/jwt/JWTUtil.java
+++ b/src/main/java/com/example/we_save/jwt/JWTUtil.java
@@ -37,8 +37,7 @@ public class JWTUtil {
 
     public String createJwt(String username, String role, Long expiredMs) {
         long currentDateTimeMillis = System.currentTimeMillis();
-//        System.out.println("issuedAt:"+new Date(currentDateTimeMillis));
-//        System.out.println("expiration"+new Date(currentDateTimeMillis+expiredMs));
+
         return Jwts.builder()
                 .claim("username", username)
                 .claim("role", role)

--- a/src/main/java/com/example/we_save/jwt/LoginFilter.java
+++ b/src/main/java/com/example/we_save/jwt/LoginFilter.java
@@ -52,7 +52,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(username, role, 60*60*3000L); //3시간
+        String token = jwtUtil.createJwt(username, role, 60*60*24000L); //24시간
         response.addHeader("Authorization", "Bearer " + token);
     }
 


### PR DESCRIPTION
- 회원 탈퇴시 회원의 status를 INACTIVE상태 변경한다.(회원 정보 삭제X)
- 로그인시 회원 상태가 INACTIVE일 경우 ACTIVE상태로 변경한다.

DB 적용해야할 스케줄러
- INACTIVE상태가 일주일이 지났을 경우 SUSPENDED로 status를 변경하고 회원의 닉네임을 '알수없음'으로 변경하고, 전화번호도 01000000000으로 변경한다. 